### PR TITLE
Create a template for bug report issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Something isn’t working as expected
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Problem description**
+A clear and concise description of what the bug is.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Environment (please complete the following information):**
+- OS: [e.g. iOS 13.2, Windows 10 v1909]
+- Browser: [e.g. chrome 79, safari 13.0.4]
+- Fonts: [e.g. v 1.036 at commit e72e93e]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
This configuration file will provide a starting template for people who file issues, to make bug reports more meaningful and easier to follow up on.

People can always just delete the suggested text and write whatever issue they want, but I find that it is very helpful to have reminders that they should include a clear issue description with screenshots, information about the font version, and information about the environment. If they exclude that information, most issues will require followup asking for it, wasting everyone’s time.